### PR TITLE
docker-compose: Workaround to resolve dapr components dir with merged docker compose files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       "--resources-path", "./components"
     ]
     volumes:
-      - "./components/:/components" # Mount our components folder for the runtime to use. The mounted location must match the --resources-path argument.
+      - "./../user_service/components/:/components" # Mount our components folder for the runtime to use. The mounted location must match the --resources-path argument.
     depends_on:
       - app-user
       - redis


### PR DESCRIPTION
Just a quick workaround because docker does not resolve paths correctly when using its function to merge multiple compose files