### PR TITLE
Improve performance of findUserInfos

### DIFF
--- a/src/main/java/de/unistuttgart/iste/gits/user_service/controller/UserController.java
+++ b/src/main/java/de/unistuttgart/iste/gits/user_service/controller/UserController.java
@@ -4,6 +4,7 @@ import de.unistuttgart.iste.gits.common.user_handling.LoggedInUser;
 import de.unistuttgart.iste.gits.generated.dto.PublicUserInfo;
 import de.unistuttgart.iste.gits.generated.dto.UserInfo;
 import de.unistuttgart.iste.gits.user_service.service.UserService;
+import graphql.schema.DataFetchingEnvironment;
 import lombok.RequiredArgsConstructor;
 import org.springframework.graphql.data.method.annotation.*;
 import org.springframework.stereotype.Controller;
@@ -24,11 +25,17 @@ public class UserController {
 
     @QueryMapping
     public UserInfo currentUserInfo(@ContextValue LoggedInUser currentUser) {
-        return userService.getUserInfo(currentUser.getId());
+        return new UserInfo(
+                currentUser.getId(),
+                currentUser.getUserName(),
+                currentUser.getFirstName(),
+                currentUser.getLastName(),
+                List.of() // course memberships are resolved with schema mapping
+        );
     }
 
     @QueryMapping
-    public List<UserInfo> findUserInfos(@Argument List<UUID> ids) {
-        return userService.findUserInfos(ids);
+    public List<UserInfo> findUserInfos(@Argument List<UUID> ids, DataFetchingEnvironment env) {
+        return userService.findUserInfos(ids, env);
     }
 }


### PR DESCRIPTION
## Description of changes

Improves performance by only fetching user data from keycloak when the relevant fields are selected in the graphql query, otherwise skips keycloak request
  
## How has this been tested?

Please describe the test strategy you followed. If not tested, please explain why.

- [x] automated unit test
- [ ] automated integration test
- [ ] manual, exploratory test
    
## Checklist before requesting a review

- [x] My code is easy to understand
- [x] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [x] My code fulfills all acceptance criteria
- [x] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation or
  the [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [x] I made no breaking changes in the database schema or if so, I will perform a database migration

## Checklist for reviewer

- The code is easy to understand
- The code follows
  the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of
  this project
- The code is tested or if not, the reason is documented or discussed
- The added and existing tests reasonably cover the code change
- The code has no breaking changes in the database schema or if so, the assignee is aware of it and
  will perform a database migration
